### PR TITLE
Fix mistake to send email at several recipients

### DIFF
--- a/classes/Message.php
+++ b/classes/Message.php
@@ -53,9 +53,9 @@ class Message extends \Tx\Mailer\Message {
         foreach($addresses as $addr) {
             // parse address
             if(preg_match('#(.*?)<(.*?)>#', $addr, $matches)) {
-                $rcpt[] = $matches[2];
+                $rcpt[] = trim($matches[2]);
             } else {
-                $rcpt[] = $addr;
+                $rcpt[] = trim($addr);
             }
         }
 


### PR DESCRIPTION
When I use this plugin to send Notifications at several
recipients, only the first recipient receives the email.

The emails of recipients must not start or end with space(s)
otherwise the SMTP instruction "RCPT TO:< my@email.com>"
doesn't work.

The list of recipients transmitted to Message class can be
composed of email separated by ", " and not only ",". When
the list of recipients is splitted thanks to delimiter ","
the email can start by space and it must be removed.

I tested this patch with DokuWiki "Detritus"

Signed-off-by: Sébastien Mennetrier <smennetrier@voxtok.com>