### PR TITLE
Fixes Got: 501 | 501 Syntax error - line too long error 

### DIFF
--- a/classes/Message.php
+++ b/classes/Message.php
@@ -85,7 +85,7 @@ class Message extends \Tx\Mailer\Message {
                 break; // header removed, we're done
             }
         }
-        $body = join("\n", $lines);
+        $body = join($this->CRLF, $lines);
 
         return $body . $this->CRLF . $this->CRLF . "." . $this->CRLF;
     }


### PR DESCRIPTION
when making considerable changes

I tried e.g. to create a 5000 word Lorem Ipsum page - mail notification  failed
I tried to replace it by a rot13 version of itself - mail notification  failed
I tried to revert the changes - mail notification failed

The fix should make sense, since the rfc states the line separator is CRLF not LF

May also be a server depend error...