### PR TITLE
Fix invalid HELO command in case of IPv6

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -19,7 +19,17 @@ class helper_plugin_smtp extends DokuWiki_Plugin {
      */
     static public function getEHLO($ehlo='') {
         if(empty($ehlo)) {
-            $ehlo = !empty($_SERVER["SERVER_ADDR"]) ? "[" . $_SERVER["SERVER_ADDR"] . "]" : "localhost.localdomain";
+            $ip = $_SERVER["SERVER_ADDR"];
+            if (empty($ip))
+              return "localhost.localdomain";
+
+            // Indicate IPv6 address according to RFC 2821, if applicable.
+            $colonPos = strpos($ip, ':');
+            if ($colonPos !== false) {
+                $ip = 'IPv6:'.$ip;
+            }
+
+            return "[" . $ip . "]";
         }
         return $ehlo;
     }


### PR DESCRIPTION
In the case that SERVER_ADDR is IPv6 (I think this is always the case when the remote visitor of the website is accessing it via IPv6), the string "IPv6:" needs to be prepended according to RFC 2821, or SMTP servers like postfix will reject the HELO due to "invalid ip address". Visitors who connect via IPv4 would not encounter this error I think, because SERVER_ADDR would then also be the IPv4 address of the server.

Maybe even better would be to always use IPv4 if the server does have an IPv4 address, even if it is visited via IPv6 at the moment. But I don't know a PHP method to just get the IPv4 address. Only a few years ago I often encountered problems with IPv6, with many mail servers (incl. GMail) rejecting mail that was sent via IPv6 due to configuration errors. But one can hope that this should be a thing of the past now.